### PR TITLE
Added filter button to bookoverview page

### DIFF
--- a/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/bookoverviewpage.html
+++ b/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/bookoverviewpage.html
@@ -1,54 +1,78 @@
 {% extends "layout.html" %}
 
 {% block content %}
-
-<div class="flex-grid">
-    {% for book in books.items %}
-    <a class="flex-row" href="{{ url_for('bookdetail', book_id=book.book_id) }}">
-        <div class="card-image-wrapper">
-            <img class="card-image" src={{ book.image_url }} alt="Card image cap">
+<div class="container body-content mx-0 px-0" style="max-width:none">
+    <div class="row">
+        <div class="col-2">
+            <div class="container-fluid">
+                <div class="row">
+                    <div class="col-3"></div>
+                    <div class="col-6">
+                        <form method="POST" action="./browse">
+                            <h4 class="pt-2">Filters</h4>
+                            {% for category in categories %}
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="true" id="{{category}}" name="{{category}}">
+                                <label class="form-check-label" for="{{category}}">
+                                    {{category.capitalize()}}
+                                </label>
+                            </div>
+                            {% endfor %}
+                            <input class="btn btn-dark" name="Toepassen" type="submit" value="Toepassen">
+                        </form>
+                    </div>
+                    <div class="col-3"></div>
+                </div>
+            </div>
         </div>
-        <div class="card-body-wrapper">
-            <p class="card-text">{{ book.title }}</p>
+
+        <div class="col-8">
+            <div class="flex-grid">
+                {% for book in books.items %}
+                <a class="flex-row" href="{{ url_for('bookdetail', book_id=book.book_id) }}">
+                    <div class="card-image-wrapper">
+                        <img class="card-image" src={{ book.image_url }} alt="Card image cap">
+                    </div>
+                    <div class="card-body-wrapper">
+                        <p class="card-text">{{ book.title }}</p>
+                    </div>
+                </a>
+                {% endfor %}
+            </div>
+
+            <div class="pagination">
+                <div class="text-right">
+                    <a href="{{ url_for('book', page=books.prev_num) }}" class="btn btn-outline-dark
+                        {% if books.page == 1 %}disabled{% endif %}">
+                        &laquo;
+                    </a>
+                    {% for page_num in books.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
+                    {% if page_num %}
+                    {% if books.page == page_num %}
+                    <a href="{{ url_for('book', page=page_num) }}" class="btn btn-dark">
+                        {{ page_num }}
+                    </a>
+                    {% else %}
+                    <a href="{{ url_for('book', page=page_num) }}" class="btn btn-outline-dark">
+                        {{ page_num }}
+                    </a>
+                    {% endif %}
+                    {% else %}
+                    ...
+                    {% endif %}
+                    {% endfor %}
+                    <a href="{{ url_for('book', page=books.next_num) }}" class="btn btn-outline-dark
+                    {% if books.page == books.pages %}disabled{% endif %}">
+                        &raquo;
+                    </a>
+                </div>
+                <p class="text-right mt-3">
+                    Showing page {{ books.page }} of {{ books.pages }}
+                </p>
+            </div>
         </div>
-    </a>
-    {% endfor %}
 
-</div>
-
-<div class="pagination">
-    <div class="text-right">
-        <a href="{{ url_for('book', page=books.prev_num) }}"
-           class="btn btn-outline-dark
-       {% if books.page == 1 %}disabled{% endif %}">
-            &laquo;
-        </a>
-        {% for page_num in books.iter_pages(left_edge=1, right_edge=1, left_current=1, right_current=2) %}
-        {% if page_num %}
-        {% if books.page == page_num %}
-        <a href="{{ url_for('book', page=page_num) }}"
-           class="btn btn-dark">
-            {{ page_num }}
-        </a>
-        {% else %}
-        <a href="{{ url_for('book', page=page_num) }}"
-           class="btn btn-outline-dark">
-            {{ page_num }}
-        </a>
-        {% endif %}
-        {% else %}
-        ...
-        {% endif %}
-        {% endfor %}
-        <a href="{{ url_for('book', page=books.next_num) }}"
-           class="btn btn-outline-dark
-       {% if books.page == books.pages %}disabled{% endif %}">
-            &raquo;
-        </a>
+        <div class="col-2"></div>
     </div>
-    <p class="text-right mt-3">
-        Showing page {{ books.page }} of {{ books.pages }}
-    </p>
 </div>
-
 {% endblock %}

--- a/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/bookpage.html
+++ b/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/bookpage.html
@@ -1,6 +1,7 @@
 ﻿{% extends "layout.html" %}
 
 {% block content %}
+<div class="container body-content">
 <div class="row">
     <div class="col-sm-12 col-md-3">
         <img class="detail-page-image" src={{ book.image_url }} alt="Card image cap">
@@ -85,6 +86,6 @@
     </div>
 
 </div>
-
+</div>
 
 {% endblock %}

--- a/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/index.html
+++ b/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/index.html
@@ -1,6 +1,7 @@
 ﻿{% extends "layout.html" %}
 
 {% block content %}
+<div class="container body-content">
 <section class="index-section">
     <h2 class="index-section-title">Latest books</h2>
     <div class="flex-grid ">
@@ -32,6 +33,6 @@
         {% endfor %}
     </div>
 </section>
-
+</div>
 
 {% endblock %}

--- a/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/layout.html
+++ b/TheBookWasBetterFlask/TheBookWasBetterFlask/TheBookWasBetterFlask/templates/layout.html
@@ -12,8 +12,9 @@
 
 <body>
     <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-color">
-        <a class="navbar-brand" href="{{ url_for('index') }}">Jugde book by description</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+        <a class="navbar-brand" href="{{ url_for('index') }}">Judge a book by its description</a>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse"
+            aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbarCollapse">
@@ -28,10 +29,7 @@
         </div>
     </nav>
 
-    <div class="container body-content">
-        {% block content %}{% endblock %}
-
-    </div>
+    {% block content %}{% endblock %}
 
     <footer class="footer-bg">
         <div class="container footer-content">


### PR DESCRIPTION
Op dit moment als je op de filter knop druk word de selectie van filters gewist, maar de boeken zijn daadwerkelijk gefilterd. Dit fix ik wel een keertje. 

Daarnaast: Als het niet erg is, hernoem ik de bookpage en boekoverviewpage naar iets anders wanneer het niet conflict. Sinds deze namen een redundant deel hebben (page) en niet echt duidelijk zijn. Iets zoals booklist en bookdetail is misschien beter. Maar dat is voor een latere PR.